### PR TITLE
Add init script to do intialiazation of submodules and installation to R and Python paths

### DIFF
--- a/notebooks/index.ipynb
+++ b/notebooks/index.ipynb
@@ -2,13 +2,39 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "9a9e9297-ac3f-43f4-a1a2-9ad7307c4c1b",
+   "id": "6189dbbd",
    "metadata": {},
    "source": [
     "# Notebooks \n",
-    "This repo contains an introduction to software packages and datasets inside the OpenSense sandbox\n",
-    "\n",
-    "\n",
+    "This repo contains an introduction to software packages and datasets inside the OpenSense sandbox"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7322d98b",
+   "metadata": {},
+   "source": [
+    "Please run the following cell first to initialize all packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ed24ea5e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import subprocess\n",
+    "subprocess.run('bash -c \"source activate notebook && bash ./init.sh\"', shell=True)\n",
+    "# or run this if you are on your local machine with the env built from the yaml file\n",
+    "#subprocess.run('bash -c \"source activate opensense_sandbox && bash ./init.sh\"', shell=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ecb34642",
+   "metadata": {},
+   "source": [
     "Here is an outline of example notebooks implemented within the sandbox:\n",
     "\n",
     "* [Datasets notebook](./Explore_existing_datasets.ipynb)\n",
@@ -33,7 +59,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/init.sh
+++ b/notebooks/init.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+source activate opensense_sandbox
+
+echo 'Running with the following python binary'
+which python
+
+cd ..
+
+echo ''
+echo 'get content of submodules...'
+git submodule update --init
+
+echo ''
+echo 'add python submodules to conda env...'
+conda develop pycomlink
+conda develop PyNNcml
+# not sure if we need this one since it currently is not 
+# used in the example notebook of Abbas which defines all
+# required functions inside the notebook
+conda develop pws-pyqc
+
+echo ''
+echo 'Install RAINLINK...'
+cd RAINLINK
+R CMD INSTALL RAINLINK*.tar.gz
+
+echo ''
+echo 'create dir in RAINLINK for figures...'
+mkdir Figures
+
+echo ''
+echo '...done'


### PR DESCRIPTION
I added a small init script and a new cell to the index notebook to run it.

Note that the script cannot just be run via `!bash init.sh` because this will run in the wrong conda env.