### PR TITLE
removed sys.path.append from the two Python CML example notebooks

### DIFF
--- a/notebooks/index.ipynb
+++ b/notebooks/index.ipynb
@@ -2,16 +2,17 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "59a69072",
+   "id": "1c95b48f",
    "metadata": {},
    "source": [
-    "### Please run the following cell first to initialize all packages"
+    "### Please run the following cell first to initialize all packages\n",
+    "(this initialization will take approx. 60 seconds)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14876ed9",
+   "id": "c69095d1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,7 +25,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c308e21b",
+   "id": "667c6f01",
    "metadata": {},
    "source": [
     "# Outline of example notebooks implemented within the sandbox:\n",
@@ -41,7 +42,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cd0beafb",
+   "id": "2c1eee97",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/pycomlink_basic_example.ipynb
+++ b/notebooks/pycomlink_basic_example.ipynb
@@ -3,19 +3,17 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "84694ea1-69eb-41df-82b3-2934d4dc834f",
+   "id": "5e2ac221",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sys\n",
-    "sys.path.append('../pycomlink/')\n",
     "import pycomlink as pycml"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "067c0fdf-cfef-49ac-a208-eabf7989e1a8",
+   "id": "cd029317",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,7 +25,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40e6fb1b-5158-44ff-93c2-553c3784c187",
+   "id": "885ded74",
    "metadata": {},
    "source": [
     "# Load data\n",
@@ -37,7 +35,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "c56b6822-c021-4c9f-a2a8-1b35d56ce776",
+   "id": "6af4bf34",
    "metadata": {},
    "outputs": [
     {
@@ -461,7 +459,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58f52f12-9fa1-4d77-9458-5c32c207586b",
+   "id": "9320ee8a",
    "metadata": {},
    "source": [
     "# Set default and fill values to NaN and calculate TRSL\n",
@@ -473,7 +471,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "d6ba9b90-87ba-43fd-b431-df7ddc7cdf32",
+   "id": "00e817fd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -486,7 +484,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fa215fbc-f126-4e62-a800-fa97f0f00891",
+   "id": "8643897e",
    "metadata": {
     "tags": []
    },
@@ -498,7 +496,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "7f9e6b12-faae-405a-aa0a-83b3275ee14f",
+   "id": "9a3723f7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -509,7 +507,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "5110fcb2-7d5a-43bb-a89b-567a2d0aed43",
+   "id": "a4333b7c",
    "metadata": {},
    "outputs": [
     {
@@ -543,7 +541,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "7e722f15-cee7-42e7-9220-273f1e1c0400",
+   "id": "bbb01d8d",
    "metadata": {},
    "outputs": [
     {
@@ -581,7 +579,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c4eb239e-e7c7-4229-8eb9-a9525eacc947",
+   "id": "659ccfd9",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -603,7 +601,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/pynncml_basic_example.ipynb
+++ b/notebooks/pynncml_basic_example.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "813c5c35-3afc-421a-9b65-d1f12c417cfc",
+   "id": "9bb3fc32",
    "metadata": {},
    "source": [
     "# Import packages"
@@ -11,7 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "95f65771-0d6b-4527-aabb-3d612bf424c2",
+   "id": "58739742",
    "metadata": {},
    "outputs": [
     {
@@ -24,8 +24,6 @@
     }
    ],
    "source": [
-    "import sys\n",
-    "sys.path.append('../PyNNcml/') # This line is need to import pynncml\n",
     "import torch\n",
     "import pynncml as pnc\n",
     "import numpy as np\n",
@@ -35,7 +33,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81ec4db7-bbee-41ba-87ca-a0d07d865f12",
+   "id": "c5e8b949",
    "metadata": {},
    "source": [
     "# Download Dataset \n",
@@ -45,7 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "369dad9d-873b-4920-b2b2-1e254045a170",
+   "id": "e5067d85",
    "metadata": {},
    "outputs": [
     {
@@ -68,7 +66,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c3f993a4-9aef-4c95-afe3-0f8ee2ea2608",
+   "id": "0ed1f387",
    "metadata": {},
    "source": [
     "# Transform Dataset to PyNNcml format\n",
@@ -78,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "43a67cc3-cdeb-49ae-a7c8-744782e344b4",
+   "id": "6743f569",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,7 +103,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b470e1ee-e81c-48a4-86ca-d0fbf31d1d56",
+   "id": "91e120b7",
    "metadata": {},
    "source": [
     "# Running Dynamic Baseline +Power Law\n",
@@ -115,7 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "44288a2e-c688-45ae-b887-3bb05cdb6cda",
+   "id": "50c5f5ce",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +123,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b3f80c3b-2062-4035-a50b-84a4bf424596",
+   "id": "d76131cb",
    "metadata": {},
    "source": [
     "# Plot\n",
@@ -135,7 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "811bccf0-3920-4739-b00f-79bdb8e45992",
+   "id": "3f921a78",
    "metadata": {},
    "outputs": [
     {
@@ -170,7 +168,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b3b1b12-8885-4caa-9152-1f46bda5e8e3",
+   "id": "4d08345d",
    "metadata": {},
    "source": [
     "# References \n",
@@ -197,7 +195,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
since the submodules are added to the conda env, they can now be run without the sys.path.append. This has the advantage that all other example notebooks that are in the pycomlink and PyNNcml submodule will just run without modification.