### PR TITLE
Updated sublink_id naming convention in notebook

### DIFF
--- a/notebooks/pynncml_basic_example.ipynb
+++ b/notebooks/pynncml_basic_example.ipynb
@@ -81,7 +81,7 @@
    "outputs": [],
    "source": [
     "sublink_index=0\n",
-    "ds_sublink=ds.isel(sublink=sublink_index)\n",
+    "ds_sublink=ds.isel(sublink_id=sublink_index)\n",
     "# frequency, polarization, length, height_far, height_near\n",
     "meta_data=pnc.MetaData(float(ds_sublink.frequency),\n",
     "                   bool(ds_sublink.polarization!='Vertical'), # Vertical 1\n",


### PR DESCRIPTION
The new data-downloader and transformer uses `sublink_id` instead of `sublink` as dimemsion in the created Datasets.

Hence the example notebooks have to be updated.