### PR TITLE
fix `sublink` kwarg in pynncml_basic_example.ipynb

### DIFF
--- a/notebooks/pynncml_basic_example.ipynb
+++ b/notebooks/pynncml_basic_example.ipynb
@@ -81,7 +81,7 @@
    "outputs": [],
    "source": [
     "sublink_index=0\n",
-    "ds_sublink=ds.isel(sublink_id=sublink_index)\n",
+    "ds_sublink=ds.isel(sublink=sublink_index)\n",
     "# frequency, polarization, length, height_far, height_near\n",
     "meta_data=pnc.MetaData(float(ds_sublink.frequency),\n",
     "                   bool(ds_sublink.polarization!='Vertical'), # Vertical 1\n",


### PR DESCRIPTION
There were changes in the data transformation code, which now only returns a xarray.Dataset with reshaped data and updated dimension (cml_id, sublink_id, time) if it is called with the option to reshape the data. Since reshaping the data takes too long to run (an might crash on binder due to limited RAM) the simplest fix is to not reshape and just use the `sublink` dimension as it is called in the existing OpenMRG NetCDF file.

At some point, the pynncml example could use the smaller example NetCDF from the OpenMRG dataset that is currently (since #62) part of the sandbox repository.